### PR TITLE
(fix): import from relative index

### DIFF
--- a/src/Block.jsx
+++ b/src/Block.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Rspan, ReactiveComponent, Hash} from 'oo7-react';
 import { bonds, formatBlockNumber} from 'oo7-parity';
 import { Bond } from 'oo7';
-import { InlineAccount } from 'parity-reactive-ui';
+import { InlineAccount } from './';
 import { Card, List, Icon} from 'semantic-ui-react'
 
 // Reactive Block view

--- a/src/Transaction.jsx
+++ b/src/Transaction.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ReactiveComponent, Rspan, Hash } from 'oo7-react';
 import { Card, List, Icon} from 'semantic-ui-react';
 import { formatBlockNumber, formatBalance } from 'oo7-parity';
-import { InlineAccount, InlineBalance } from 'parity-reactive-ui';
+import { InlineAccount, InlineBalance } from './';
 
 // supports:
 // gas: true,


### PR DESCRIPTION
Importing from `parity-reactive-ui` would actually try to import a different version of itself (?)  to compile. This shouldn't be the case, and these components should refer to the local one.

> NOTE: import {} from './' is pretty much import {} from './index' 

Without this, local version will not compile properly, unless one install this package itself globally/locally.

@gavofyork @kaikun213 